### PR TITLE
add support for specifying host & backlog (not only the port) on app.listen() - via dna.host & dna.backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Organelle constructing expressjs app and opening http server listening port
     "organic-express-server": {
       "source": "node_modules/organic-express-server",
       "port": 1337,
+      "host": "127.0.0.1", // (String) if not defined = listen to all interfaces. https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback
+      "backlog": 511, // (Number) maximum length of the queue of pending connections. The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux. The default value of this parameter is 511 (not 512). https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback
       "logRunning": true,
-      "initScript": "init-express-app", 
+      "initScript": "init-express-app",
       "emitReady": "ExpressServer",
       "closeOn": "kill",
       "forceConnectionsDestroyOnClose": false

--- a/index.js
+++ b/index.js
@@ -1,37 +1,54 @@
-var express = require("express")
-var path = require("path")
+var express = require('express')
+var path = require('path')
 
-module.exports = function(plasma, dna) {
-  var completeAppInit = function(app){
-    var server = app.listen(dna.port, function(){
-      if(dna.logRunning)
-        console.log("express server running on", dna.port)
+module.exports = function (plasma, dna) {
+  var completeAppInit = function (app) {
+    var callback = function () {
+      if (dna.logRunning) {
+        console.log('express server running on', (dna.host || '*') + ':' + dna.port)
+      }
       plasma.emit({
-        type: dna.emitReady || "ExpressServer",
+        type: dna.emitReady || 'ExpressServer',
         data: app,
         server: server
       })
-    });
-    var sockets = {}, nextSocketId = 0;
-    if(dna.forceConnectionsDestroyOnClose)
+    }
+    var server
+    if (typeof dna.host === 'string' && dna.host) {
+      if (typeof dna.backlog === 'number') {
+        server = app.listen(dna.port, dna.host, dna.backlog, callback)
+      } else {
+        server = app.listen(dna.port, dna.host, callback)
+      }
+    } else {
+      server = app.listen(dna.port, callback)
+    }
+    var sockets = {}
+    var nextSocketId = 0
+    if (dna.forceConnectionsDestroyOnClose) {
       server.on('connection', function (socket) {
-        var socketId = nextSocketId++;
-        sockets[socketId] = socket;
+        var socketId = nextSocketId++
+        sockets[socketId] = socket
         socket.on('close', function () {
-          delete sockets[socketId];
-        });
+          delete sockets[socketId]
+        })
       })
-    plasma.on(dna.closeOn || "kill", function(c, next){
-      if(dna.forceConnectionsDestroyOnClose)
-        for (var socketId in sockets)
-          sockets[socketId].destroy();
-      server.close(function(){
+    }
+
+    plasma.on(dna.closeOn || 'kill', function (c, next) {
+      if (dna.forceConnectionsDestroyOnClose) {
+        for (var socketId in sockets) {
+          sockets[socketId].destroy()
+        }
+      }
+      server.close(function () {
         next()
       })
     })
   }
-  if(dna.initScript) {
-    require(path.join(process.cwd(), dna.initScript))(plasma, dna, function(err, app){
+
+  if (dna.initScript) {
+    require(path.join(process.cwd(), dna.initScript))(plasma, dna, function (err, app) {
       if(err) throw err
       completeAppInit(app)
     })

--- a/index.js
+++ b/index.js
@@ -41,9 +41,7 @@ module.exports = function (plasma, dna) {
           sockets[socketId].destroy()
         }
       }
-      server.close(function () {
-        next()
-      })
+      server.close(next)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -14,15 +14,15 @@ module.exports = function (plasma, dna) {
       })
     }
     var server
-    if (typeof dna.host === 'string' && dna.host) {
-      if (typeof dna.backlog === 'number') {
-        server = app.listen(dna.port, dna.host, dna.backlog, callback)
-      } else {
-        server = app.listen(dna.port, dna.host, callback)
-      }
-    } else {
-      server = app.listen(dna.port, callback)
+    var args = [dna.port]
+    if (typeof dna.host === 'string') {
+      args.push(dna.host)
     }
+    if (typeof dna.backlog === 'number') {
+      args.push(dna.backlog)
+    }
+    args.push(callback)
+    server = app.listen.apply(app, args)
     var sockets = {}
     var nextSocketId = 0
     if (dna.forceConnectionsDestroyOnClose) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var path = require('path')
 
 module.exports = function (plasma, dna) {
   var completeAppInit = function (app) {
+    var server
     var callback = function () {
       if (dna.logRunning) {
         console.log('express server running on', (dna.host || '*') + ':' + dna.port)
@@ -13,7 +14,6 @@ module.exports = function (plasma, dna) {
         server: server
       })
     }
-    var server
     var args = [dna.port]
     if (typeof dna.host === 'string') {
       args.push(dna.host)


### PR DESCRIPTION
add support for specifying host & backlog (not only the port) on app.listen() - via `dna.host` & `dna.backlog`

+few code style improvements

:dancers: :rocket: 